### PR TITLE
Skip oraclejdk7 and openjdk6 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: java
 jdk:
   - oraclejdk8
-  - oraclejdk7
-  - openjdk6
+#  - oraclejdk7
+#  - openjdk6
 install: 
   - ant
 before_script: 


### PR DESCRIPTION
Commented oraclejdk7 and openjdk6 as these are currently broken on Travis-CI trusty dist. See discussion on Travis forum.